### PR TITLE
Shrink unsafe block for the Node impl

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -60,12 +60,11 @@ impl<T: Ord> Node<T> {
     /// fails otherwise. Sets both pointers, so node lifetime will be
     /// managed by parent.
     pub(crate) fn with_parent(data: T, parent: *mut Node<T>, side: Side) -> *mut Node<T> {
-        unsafe {
-            let new: *mut Node<T> = alloc(Layout::new::<Node<T>>()) as *mut Node<T>;
+            let new: *mut Node<T> = unsafe { alloc(Layout::new::<Node<T>>()) as *mut Node<T> };
 
-            (*(*parent).child_raw(&side)) = Some(new);
+            unsafe { (*(*parent).child_raw(&side)) = Some(new) };
 
-            *new = Node {
+            unsafe { *new = Node {
                 data,
                 color: Color::Red,
                 parent: Some(Parent {
@@ -74,10 +73,9 @@ impl<T: Ord> Node<T> {
                 }),
                 left: None,
                 right: None,
-            };
+            } };
 
             new
-        }
     }
 
     /// Recursive insert function.


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 